### PR TITLE
Fix render artifacts around health points when the HUD is scaled.

### DIFF
--- a/src/client/cl_screen.c
+++ b/src/client/cl_screen.c
@@ -949,7 +949,7 @@ SCR_DrawFieldScaled(int x, int y, int color, int width, int value, float factor)
 	}
 
 	SCR_AddDirtyPoint(x, y);
-	SCR_AddDirtyPoint(x + (width * CHAR_WIDTH + 2)*factor, y + 23);
+	SCR_AddDirtyPoint(x + (width * CHAR_WIDTH + 2)*factor, y + factor*24);
 
 	Com_sprintf(num, sizeof(num), "%i", value);
 	l = (int)strlen(num);


### PR DESCRIPTION
In SCR_DrawFieldScaled() the HUD scale factor wasn't taken into account
when calculating the screen area affected by the change. Therefor wrong
coordinates were passed to SCR_AddDirtyPoint() and a part of the changed
area wasn't marked dirty, leading to render artifacts.

This bug was present since HUD scaling was first introduced.